### PR TITLE
Add support for COPY for more efficient data loading

### DIFF
--- a/src/nycdb/database.py
+++ b/src/nycdb/database.py
@@ -33,7 +33,7 @@ class Database:
             curs.execute(SQL)
         self.conn.commit()
 
-    def insert_rows(self, rows, table_name=None):
+    def insert_rows(self, rows, table_name=None, use_copy=False):
         """
         Inserts many rows, all in the same transaction using executemany
         """
@@ -43,7 +43,10 @@ class Database:
 
         with self.conn.cursor() as curs:
             try:
-                curs.execute(sql.insert_many(curs, table_name, rows))
+                if use_copy:
+                    sql.copy(curs, table_name, rows)
+                else:
+                    curs.execute(sql.insert_many(curs, table_name, rows))
             except psycopg.Error:
                 print(rows)  # useful for debugging
                 raise
@@ -73,7 +76,7 @@ class Database:
             table_name
         )
         return self.execute_and_fetchone(query)
-    
+
     def get_current_db_schema(self):
         search_path = self.execute_and_fetchone("SHOW search_path;")
         # default search_path is '"$user", public'

--- a/src/nycdb/dataset.py
+++ b/src/nycdb/dataset.py
@@ -134,7 +134,7 @@ class Dataset:
                 break
             else:
                 pbar.update(len(batch))
-                self.db.insert_rows(batch, table_name=schema["table_name"])
+                self.db.insert_rows(batch, table_name=schema["table_name"], use_copy=schema["use_copy"])
         pbar.close()
 
     def create_schema(self):


### PR DESCRIPTION
This is a draft! I'm still looking into a better implementation and would like to provide some performance metrics on how this exactly performs faster compared to the default `insert_many` function as well as investigate if this solution is viable at all.

**Motivation**

[Postgresql's COPY protocol](https://www.postgresql.org/docs/current/sql-copy.html) can be an efficient method of loading mass amounts of data into a psql cluster.  Based on previous discussions: https://github.com/nycdb/nycdb/pull/257#discussion_r1276833336, it seems that it's an approach worth investigating in order to reduce the overall load-step time for many large datasets, most notably `pluto_22v1` and`pluto_23v1`.

**Results so Far**

Based on my naive approach, we can already see improvements when testing the loading of `mci_application` dataset:

Test was done locally on my M1 macbook air with postgres running locally.

Using `copy`:
```
$ nycdb --load mci_applications
26782rows [00:00, 33989.64rows/s]
time elapsed: 1.0873405839956831
```

Using `insert_many`
```
$ nycdb --load mci_applications
26782rows [00:02, 11343.27rows/s]
time elapsed 2.638788582989946
```
